### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/AutoGen/README.md
+++ b/AutoGen/README.md
@@ -36,7 +36,7 @@ python >=3.8 & <3.13
 
 安装 `AutoGen`
 ```sh
-pip install pyautogen
+pip install ag2
 ```
 
 
@@ -85,7 +85,7 @@ AutoGen 支持 RAG，通过在 LLM 的输入中添加来自外部数据源的文
 ### envs
 ```bash
 # 加 -q 控制台没有安装信息
-pip install pyautogen[retrievechat] langchain "chromadb<0.4.15" -q
+pip install ag2[retrievechat] langchain "chromadb<0.4.15" -q
 ```
 
 <br>

--- a/Chainlit/requirements.txt
+++ b/Chainlit/requirements.txt
@@ -255,7 +255,7 @@ pyairports==2.1.1
 pyaml-env==1.2.1
 pyarrow==15.0.2
 pyarrow-hotfix==0.6
-pyautogen==0.2.33
+ag2==0.2.33
 pycodestyle==2.12.1
 pycountry==24.6.1
 pycparser==2.22


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
